### PR TITLE
eslint/prettierで正しくファイル指定されるように

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint --dir src/**/*.{ts,tsx}",
-    "fmt": "prettier --write src/**/*.{ts,tsx}",
+    "lint": "next lint --dir src --ext .js,.jsx,.ts,.tsx",
+    "fmt": "prettier --write src",
     "prepare": "husky"
   },
   "dependencies": {


### PR DESCRIPTION
https://github.com/comb19/chat_front/pull/1 の変更では環境によって上手く動作しなかったため、src配下を全て指定するように修正した。